### PR TITLE
AIR-48398: NetMQ exception can crash symphony when using experimental players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ _ReSharper*/
 
 # Ignore NuGet Packages
 /src/packages/
+
+# Ignore Visual Studio Files
+.vs/

--- a/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
@@ -19,6 +19,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define ADD_ERROR_CODE_MESSAGE
+
 using System;
 using System.Diagnostics;
 using System.Net.Sockets;
@@ -235,8 +237,13 @@ namespace NetMQ.Core.Transports.Tcp
                 {
                     m_acceptedSocket.Dispose();
 
-                    NetMQException exception = NetMQException.Create(socketError);
+#if ADD_ERROR_CODE_MESSAGE
+                    var message = $"An error occurred during NetMQ {nameof(InCompleted)} : {nameof(socketError)} = {socketError.ToString()} ({(int)socketError}), {nameof(bytesTransferred)} = {bytesTransferred}";
 
+                    NetMQException exception = NetMQException.Create(message, socketError.ToErrorCode());
+#else                        
+                    NetMQException exception = NetMQException.Create(socketError);
+#endif
                     m_socket.EventAcceptFailed(m_endpoint, exception.ErrorCode);
                     throw exception;
                 }


### PR DESCRIPTION
Adding better exception message.